### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A TypeScript-based MCP server that integrates with Jira, allowing Cursor to interact with Jira tickets.
 
+<a href="https://glama.ai/mcp/servers/@kornbed/jira-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kornbed/jira-mcp-server/badge" alt="Jira Server for Cursor MCP server" />
+</a>
+
 ## Features
 
 - List Jira tickets
@@ -225,11 +229,6 @@ Comment text
 [3/20/2024, 9:30:00 AM] Jane Smith:
 Another comment
 ---
-```
-
-### Get Ticket Comments
-```
-GET /api/tickets/:id/comments
 ```
 
 ### Create Ticket


### PR DESCRIPTION
This PR adds a badge for the [Jira MCP Server for Cursor](https://glama.ai/mcp/servers/@kornbed/jira-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kornbed/jira-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kornbed/jira-mcp-server/badge" alt="Jira Server for Cursor MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new badge linking to the Jira MCP server page.
  - Removed a duplicate "Get Ticket Comments" section from the API Endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->