### PR TITLE
Feat/include linked issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,6 @@ Another comment
 ---
 ```
 
-### Get Ticket Comments
-```
-GET /api/tickets/:id/comments
-```
-
 ### Create Ticket
 
 Creates a new Jira ticket.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ Another comment
 ---
 ```
 
+### Get Ticket Comments
+```
+GET /api/tickets/:id/comments
+```
+
 ### Create Ticket
 
 Creates a new Jira ticket.


### PR DESCRIPTION
When fetching a work item, include linked issues in the response information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Ticket details now display parent or epic information when available.
  - Linked issues are listed within ticket details, showing keys, summaries, and link types.

- **Documentation**
  - Added API documentation for retrieving ticket comments via the `/api/tickets/:id/comments` endpoint.

- **Refactor**
  - Improved ticket creation to support optional parent linkage for next-gen projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->